### PR TITLE
 Add missing exception for SQLiteConnection.Open

### DIFF
--- a/dotnet/xml/Microsoft.Data.Sqlite/SqliteConnection.xml
+++ b/dotnet/xml/Microsoft.Data.Sqlite/SqliteConnection.xml
@@ -486,6 +486,7 @@
             </summary>
         <remarks>To be added.</remarks>
         <exception cref="T:Microsoft.Data.Sqlite.SqliteException">A SQLite error occurs while opening the connection.</exception>
+        <exception cref="T:System.NotSupportedException">An unsupported version was specified in the connection string.</exception>
       </Docs>
     </Member>
     <Member MemberName="ServerVersion">


### PR DESCRIPTION
Added a missing `System.NotSupportedException` to `SQLiteConnection.Open` documentation. This exception is being thrown when an unsupported version is specified in the connection string.